### PR TITLE
refactor: `indicies` → `indices`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ All [sample text](data/zhlipsum.json) is excerpted from `zhlipsum` LaTeX package
 ```typst
 #import "@preview/kouhu:0.1.0": kouhu
 
-#kouhu(index: range(1, 3)) // select the first 3 paragraphs from default text
+#kouhu(indices: range(1, 3)) // select the first 3 paragraphs from default text
 
 #kouhu(builtin-text: "zhufu", offset: 5, length: 100) // select 100 characters from the 5th paragraph of "zhufu" text
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ All [sample text](data/zhlipsum.json) is excerpted from `zhlipsum` LaTeX package
 ```typst
 #import "@preview/kouhu:0.1.0": kouhu
 
-#kouhu(indicies: range(1, 3)) // select the first 3 paragraphs from default text
+#kouhu(index: range(1, 3)) // select the first 3 paragraphs from default text
 
 #kouhu(builtin-text: "zhufu", offset: 5, length: 100) // select 100 characters from the 5th paragraph of "zhufu" text
 
@@ -31,7 +31,7 @@ GitHub Copilot says:
 ### 0.1.1
 
 * Fix some wrong paths in `README.md`.
-* Fix genearation of `indicies` when not specified by user.
+* Fix generation of `indicies` when not specified by user.
 * Add repetition of text until `length` is reached.
 
 ### 0.1.0

--- a/doc/manual.typ
+++ b/doc/manual.typ
@@ -27,7 +27,7 @@
     All builtin text samples are excerpted from `zhlipsum` (w/o non-UTF-8 paragraphs). Please refer to #link("http://mirrors.ctan.org/macros/latex/contrib/zhlipsum/zhlipsum-en.pdf")[its documentation] for detailed description.
     #text(font: "Noto Serif CJK SC", size: 10pt, (
       for k in builtin-text-list().keys() {[
-        + #raw(k): #kouhu(builtin-text: k, index: 1, length: 70)
+        + #raw(k): #kouhu(builtin-text: k, indices: 1, length: 70)
         #parbreak()
       ]}
     ))

--- a/doc/manual.typ
+++ b/doc/manual.typ
@@ -27,7 +27,7 @@
     All builtin text samples are excerpted from `zhlipsum` (w/o non-UTF-8 paragraphs). Please refer to #link("http://mirrors.ctan.org/macros/latex/contrib/zhlipsum/zhlipsum-en.pdf")[its documentation] for detailed description.
     #text(font: "Noto Serif CJK SC", size: 10pt, (
       for k in builtin-text-list().keys() {[
-        + #raw(k): #kouhu(builtin-text: k, indicies: (1,), length: 70)
+        + #raw(k): #kouhu(builtin-text: k, index: 1, length: 70)
         #parbreak()
       ]}
     ))

--- a/lib.typ
+++ b/lib.typ
@@ -13,11 +13,11 @@
 ///
 /// *Example 1:*
 /// Cut the first several characters of a paragraph from Lu Xun's _Zhufu_（《祝福》）.
-/// #example(`#kouhu(builtin-text: "zhufu", index: 18, length: 99)`, mode: "markup")
+/// #example(`#kouhu(builtin-text: "zhufu", indices: 18, length: 99)`, mode: "markup")
 ///
 /// *Example 2:*
 /// Cut multiple paragraphs from Lu Xun's _Zhufu_（《祝福》）.
-/// #example(`#kouhu(builtin-text: "zhufu", offset: 5, index: (2, 18), length: 31, between-para: "——")`, mode: "markup")
+/// #example(`#kouhu(builtin-text: "zhufu", offset: 5, indices: (2, 18), length: 31, between-para: "——")`, mode: "markup")
 ///
 /// *Example 3:*
 /// Repeat some text until the specified length.
@@ -25,7 +25,7 @@
 /// - builtin-text (string): Name of the builtin text, see @@builtin-text-list() for a full list and length.
 /// - custom-text (array): Custom text to use. If not `none`, `builtin-text` will be ignored.
 /// - offset (int): Offset of the paragraph to start from.
-/// - index (int, array): Indices (*NOT RANGE*) of paragraphs to use (`offset` will be added). A single integer means a single paragraph, an array means multiple paragraphs, and `none` means all paragraphs. Any out-of-bound index will be ignored.
+/// - indices (int, array): Indices (*NOT RANGE*) of paragraphs to use (`offset` will be added). A single integer means a single paragraph, an array means multiple paragraphs, and `none` means all paragraphs. Any out-of-bound index will be ignored.
 /// - length (int): Length of grapheme (characters) to print. `kouhu` will repeat over selected paragraphs until `length` is reached, and the final paragraph will likely be truncated. 0 for unlimited, i.e. print all selected paragraphs for only once.
 /// - before-para (content): Content inserted before each paragraph.
 /// - after-para (content): Content inserted after each paragraph.
@@ -35,7 +35,7 @@
   builtin-text: "simp",
   custom-text: none,
   offset: 0,
-  index: none,
+  indices: none,
   length: 0,
   before-para: none,
   after-para: none,
@@ -55,12 +55,12 @@
 
   // normalize indices
   let selected_para = ()
-  let indices = if index == none {
+  indices = if indices == none {
     range(1, text.len() + 1)
-  } else if type(index) == int {
-    (index,)
+  } else if type(indices) == int {
+    (indices,)
   } else {
-    index
+    indices
   }
 
   // select paragraphs according to argument, and

--- a/lib.typ
+++ b/lib.typ
@@ -12,17 +12,21 @@
 /// Output selected Chinese lorem ipsum paragraphs.
 ///
 /// *Example 1:*
-/// Cut some paragraphs from Lu Xun's _Zhufu_（《祝福》）.
-/// #example(`#kouhu(builtin-text: "zhufu", offset: 5, indicies: (2, 18), length: 31, between-para: "——")`, mode: "markup")
+/// Cut the first several characters of a paragraph from Lu Xun's _Zhufu_（《祝福》）.
+/// #example(`#kouhu(builtin-text: "zhufu", index: 18, length: 99)`, mode: "markup")
 ///
 /// *Example 2:*
+/// Cut multiple paragraphs from Lu Xun's _Zhufu_（《祝福》）.
+/// #example(`#kouhu(builtin-text: "zhufu", offset: 5, index: (2, 18), length: 31, between-para: "——")`, mode: "markup")
+///
+/// *Example 3:*
 /// Repeat some text until the specified length.
 /// #example(`#kouhu(custom-text: ("奥利",), between-para: none, length: 31)`, mode: "markup")
 /// - builtin-text (string): Name of the builtin text, see @@builtin-text-list() for a full list and length.
 /// - custom-text (array): Custom text to use. If not `none`, `builtin-text` will be ignored.
 /// - offset (int): Offset of the paragraph to start from.
-/// - indicies (array): Indicies (*NOT RANGE*) of paragraphs to use (`offset` will be added). `none` means all paragraphs. Any out-of-bound index will be ignored.
-/// - length (int): Length of graphme (characters) to print. `kouhu` will repeat over selected paragraphs until `length` is reached, and the final paragraph will likely be truncated. 0 for unlimited, i.e. print all selected paragraphs for only once.
+/// - index (int, array): Indices (*NOT RANGE*) of paragraphs to use (`offset` will be added). A single integer means a single paragraph, an array means multiple paragraphs, and `none` means all paragraphs. Any out-of-bound index will be ignored.
+/// - length (int): Length of grapheme (characters) to print. `kouhu` will repeat over selected paragraphs until `length` is reached, and the final paragraph will likely be truncated. 0 for unlimited, i.e. print all selected paragraphs for only once.
 /// - before-para (content): Content inserted before each paragraph.
 /// - after-para (content): Content inserted after each paragraph.
 /// - between-para (content): Content inserted between two paragraphs (has no effect if only one paragraph is selected).
@@ -31,7 +35,7 @@
   builtin-text: "simp",
   custom-text: none,
   offset: 0,
-  indicies: none,
+  index: none,
   length: 0,
   before-para: none,
   after-para: none,
@@ -49,14 +53,18 @@
     }
   }
 
-  // normalize indicies
+  // normalize indices
   let selected_para = ()
-  if indicies == none {
-    indicies = range(1, text.len() + 1)
+  let indices = if index == none {
+    range(1, text.len() + 1)
+  } else if type(index) == int {
+    (index,)
+  } else {
+    index
   }
 
   // select paragraphs according to argument, and
-  // truncate to specified length of graphme
+  // truncate to specified length of grapheme
   let length_set = false
   let remaining = 1e10 // use a large number here
   if length > 0 {
@@ -64,7 +72,7 @@
     length_set = true
   }
   while remaining > 0 {
-    for i in indicies {
+    for i in indices {
       let i_ = i + offset - 1
       if i_ >= 0 and i_ < text.len() {
         let t = text.at(i_).clusters()


### PR DESCRIPTION
- 改正拼写错误 / fix typos
- `indices`支持传入单个数字 / support passing a single number to `indices`

Resolves #1

### [manual.pdf](https://github.com/user-attachments/files/18254427/manual.pdf) compiled from this PR

(I did not commit the PDF to the repo due to the lack of fonts.)



![图片](https://github.com/user-attachments/assets/f620edf0-92b4-43be-8dd0-5638538de6b0)

![图片](https://github.com/user-attachments/assets/37936e96-69a1-4fac-81b1-20d1ff56fb73)
